### PR TITLE
docs: fix typo in readme and small rephrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Xplorer is currently on development progress. Suggest improvement on Xplorer [Di
 
 ### Installation
 
-You can access the insider version [here](https://github.com/kimlimjustin/xplorer/releases). Please not that this is not stable yet. Use it on your own risk.
+You can access the insider version [here](https://github.com/kimlimjustin/xplorer/releases). Please note that it is not stable yet. Use it on your own risk.
 
 ### LICENSE
 


### PR DESCRIPTION
## Motivation

Was just looking around after a post on dev.to and was a little confused by the `not` until I realized it was a `note`.

## Changes

Fix typo `not` to `note`. Also changed another word that, for me, sounds slightly better but may be up to discussion.
