### PR TITLE
fix: make close settings button clickable

### DIFF
--- a/src/Components/Setting/setting.scss
+++ b/src/Components/Setting/setting.scss
@@ -104,8 +104,10 @@
 	}
 
 	.exit-setting-btn {
-		font-size: 1.5rem;
 		cursor: pointer;
+	}
+	.exit-setting-icon {
+		font-size: 1.5rem;
 	}
 	.settings-title {
 		margin: 1.5rem 0 0.5rem 0;

--- a/src/Public/index.html
+++ b/src/Public/index.html
@@ -81,8 +81,14 @@
 		</div>
 		<div class="settings">
 			<div class="settings-sidebar">
-				<div class="settings-sidebar-header sidebar-hover-effect">
-					<span class="exit-setting-btn">↑</span>
+				<div
+					class="
+						settings-sidebar-header
+						exit-setting-btn
+						sidebar-hover-effect
+					"
+				>
+					<span class="exit-setting-icon">↑</span>
 					<span class="settings-sidebar-heading">Settings</span>
 				</div>
 				<div class="settings-sidebar-items"></div>


### PR DESCRIPTION
## Motivation

Close settings button was not entirely clickable. User had to click on the up-arrow icon (↑) to close it.

## Changes

Bug fixed. Added the `exit-setting-btn` class to parent which was previously added to up-arrow icon. Adding this made the whole close/exit settings button clickable.

## Related

Issue #61 
