### PR TITLE
bug: disable spell check on filepath input

### DIFF
--- a/src/Public/index.html
+++ b/src/Public/index.html
@@ -55,6 +55,7 @@
 							class="path-navigator"
 							type="text"
 							value="xplorer://Home"
+							spellcheck="false"
 						/>
 						<div class="menu">
 							<img


### PR DESCRIPTION
## Motivation

Spell check was in place at the file path input which resulted in red swiggly lines below texts. That didn't look nice!

## Changes

Adding spellcheck="false" attribute to `input type="text"` resolved it. 

## Related

Issue #70 

