### PR TITLE
bug: ignore keyboard shortcuts if filepath navigator is in focus

### DIFF
--- a/src/Components/Shortcut/shortcut.ts
+++ b/src/Components/Shortcut/shortcut.ts
@@ -59,6 +59,13 @@ const Shortcut = (): void => {
 		e.preventDefault();
 		const selectedFilePath = unescape(getSelected()?.[0]?.dataset?.path);
 		const isDir = getSelected()?.[0]?.dataset.isdir === 'true';
+
+		// Check if file navigator input is in focus, if it is then ignore key shortcuts
+		if (
+			document.querySelector('.path-navigator') === document.activeElement
+		)
+			return;
+
 		// Select all shortcut (Ctrl + A)
 		if (e.key === 'a' && e.ctrlKey) {
 			selectedAll = !selectedAll;


### PR DESCRIPTION
## Motivation

Whenever file path navigator was in focus, pressing keyboard shortcuts worked. For example, when input was focused, pressing CTRL+SHIFT+N opened up new folder window. Similarly, happened for other keyboard shortcuts.

## Changes

Patched it with a simple check if keyboard shortcut gets triggered and input is already in focus mode, ignore it.

## Related

Issue #70 
