### PR TITLE
bug: make properties box exit entirely when closed

### DIFF
--- a/src/Components/Properties/properties.scss
+++ b/src/Components/Properties/properties.scss
@@ -29,6 +29,6 @@
 		right: 2rem;
 	}
 	to {
-		right: -50vw;
+		right: -100vw;
 	}
 }


### PR DESCRIPTION
## Motivation

After clicking on file properties, it shows perfectly but when close properties, it stay on right side corner when filename/filepath consist of more characters.

## Changes

keyframes for `close-properties` rule was set to `right: -50vw` instead of `-100vw`

## Related

Issue: #72 #54 
