### PR TITLE
Do not navigate if the path navigator is empty

### DIFF
--- a/src/Components/Files/File Operation/open.ts
+++ b/src/Components/Files/File Operation/open.ts
@@ -231,6 +231,8 @@ const displayFiles = async (files: fileData[], dir:string, options?: {reveal: bo
  * @returns {Promise<void>}
  */
 const open = async (dir:string, reveal?:boolean):Promise<void> => {
+    if (!dir) return
+
     const initialDirToOpen = dir;
     closePreviewFile()
     timeStarted = Date.now()

--- a/src/Components/Layout/windowManager.ts
+++ b/src/Components/Layout/windowManager.ts
@@ -61,7 +61,7 @@ const windowManager = (): void => {
 		.addEventListener(
 			'change',
 			(event: Event & { target: HTMLInputElement }) => {
-				if (event.target.value) open(event.target.value);
+				open(event.target.value);
 			}
 		);
 };

--- a/src/Components/Layout/windowManager.ts
+++ b/src/Components/Layout/windowManager.ts
@@ -61,7 +61,7 @@ const windowManager = (): void => {
 		.addEventListener(
 			'change',
 			(event: Event & { target: HTMLInputElement }) => {
-				open(event.target.value);
+				if (event.target.value) open(event.target.value);
 			}
 		);
 };


### PR DESCRIPTION
## Motivation

Seems pointless to try to walk an empty path

## Changes

Added a check for the presence of a path before the navigate