### PR TITLE
Ignore arrow keys for select files if path navigator has focus

### DIFF
--- a/src/Components/Files/File Operation/select.ts
+++ b/src/Components/Files/File Operation/select.ts
@@ -98,6 +98,9 @@ const Initializer = () => {
 		latestSelected = firstFileElement as HTMLElement;
 	};
 	const selectShortcut = (e: KeyboardEvent) => {
+		// Ignore keyboard shortcuts for select files if path navigator has focus
+		if (document.querySelector('.path-navigator') === document.activeElement) return;
+
 		const hideHiddenFiles =
 			storage.get('preference')?.data?.hideHiddenFiles ?? true;
 		if (e.key === 'ArrowRight' && !e.altKey) {


### PR DESCRIPTION
## Motivation

Supplement #73 

## Changes

Adds check to ignore arrow keys for select files if path navigator has focus

## Related

#73
