### PR TITLE
fix(locales): remove unnecessary explanation from the "русский язык"

### DIFF
--- a/src/Locales/index.json
+++ b/src/Locales/index.json
@@ -9,7 +9,7 @@
 		"中文 (繁體)": "zh-TW",
 		"한국어": "ko-KR",
 		"Portuguese, Brazilian": "pt-BR",
-		"русский язык": "ru-RU",
+		"Русский": "ru-RU",
 		"Français": "fr-FR"
 	}
 }


### PR DESCRIPTION
## Changes

Just removed the unnecessary clarification that this is a language (язык) and made the word "русский" (russian) with a uppercase letter
