### PR TITLE
Use <code> instead of <kbd>

### DIFF
--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -81,7 +81,7 @@ Adopted from [Stack Overflow](https://stackoverflow.com/questions/65488839/how-c
 </details>
 <details>
 <summary>
-<kbd>“Xplorer” cannot be opened because the developer cannot be verified.</kbd> Error on macOS
+<code>“Xplorer” cannot be opened because the developer cannot be verified.</code> Error on macOS
 </summary>
 
 Please try [the official docs](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac) by Apple.


### PR DESCRIPTION
You can use `<code>` tags instead of `<kbd>` where markdown backtics don't work.