### PR TITLE
fix: files with file name more than 30 characters won't able to be operated

### DIFF
--- a/src/Components/Files/File Operation/open.ts
+++ b/src/Components/Files/File Operation/open.ts
@@ -162,27 +162,15 @@ const displayFiles = async (files: fileData[], dir:string, options?: {reveal: bo
             switch (layout) {
                 case "m":
                     fileGrid.classList.add("medium-grid-view")
-                    dirent.name =
-						dirent.name.length > 30
-							? dirent.name.substring(0, 30) + '...'
-							: dirent.name;
                     break;
                 case "l":
                     fileGrid.classList.add("large-grid-view")
-                    dirent.name =
-						dirent.name.length > 40
-							? dirent.name.substring(0, 40) + '...'
-							: dirent.name;
                     break;
                 case "d":
                     fileGrid.classList.add("detail-view")
                     break;
                 default:
                     fileGrid.classList.add("small-grid-view")
-                    dirent.name =
-						dirent.name.length > 20
-							? dirent.name.substring(0, 20) + '...'
-							: dirent.name;
                     break;
 
             }

--- a/src/Components/Files/files.scss
+++ b/src/Components/Files/files.scss
@@ -23,7 +23,6 @@
 }
 
 .file-grid {
-	border: 2px solid transparent;
 	display: inline-block;
 	margin: 0.5rem 1rem;
 	padding: 0.5rem;
@@ -81,17 +80,25 @@
 
 .large-grid-view {
 	width: 12rem;
+	vertical-align: top;
 	.file-grid-preview {
 		max-width: 12rem;
 		height: 9rem;
+	}
+	.file-grid-filename {
+		-webkit-line-clamp: 4;
 	}
 }
 
 .medium-grid-view {
 	width: 9rem;
+	vertical-align: top;
 	.file-grid-preview {
 		max-width: 9rem;
 		height: 6rem;
+	}
+	.file-grid-filename {
+		-webkit-line-clamp: 3;
 	}
 }
 
@@ -99,6 +106,13 @@
 	margin: 0 auto;
 	font-weight: bold;
 	text-align: center;
+}
+
+.small-grid-view {
+	vertical-align: top;
+	.file-grid-filename {
+		-webkit-line-clamp: 2;
+	}
 }
 
 [data-hide-hidden-files='true'] [data-hidden-file] {


### PR DESCRIPTION
## Motivation

As a result of merging #89, files/folders with name more than 30 characters won't able to be operated because as #89 only take file name up to 30 characters.

## Changes

Use CSS to resolve character limits

## Related
#89 #126 

## Additional Comments

Could you please review this? @dkhd 