### PR TITLE
fix: Add missed role for submenu items

### DIFF
--- a/src/Components/ContextMenu/configs/bodyMenu.config.ts
+++ b/src/Components/ContextMenu/configs/bodyMenu.config.ts
@@ -11,6 +11,8 @@ import Properties from '../../Properties/properties';
 import focusingPath from '../../Functions/focusingPath';
 import openInTerminal from '../../Functions/openInTerminal';
 import Translate from '../../I18n/i18n';
+import New from '../../Functions/new';
+
 interface Favorites {
 	name: string;
 	path: string;
@@ -180,8 +182,8 @@ const BodyMenu = (
 				menu: Translate('New'),
 				visible: !focusingPath().startsWith('xplorer://'),
 				submenu: [
-					{ name: Translate('Folder'), shortcut: 'Shift+N' },
-					{ name: Translate('File'), shortcut: 'Alt+N' },
+					{ name: Translate('Folder'), shortcut: 'Shift+N', role: () => New('folder') },
+					{ name: Translate('File'), shortcut: 'Alt+N', role: () => New('file') },
 				],
 				icon: 'new',
 			},


### PR DESCRIPTION
## Motivation
Fix submenu behavior for new -> file and new -> folder items

## Changes
1. Add `role` function for new -> file
2. Add `role` function for new -> folder
