### PR TITLE
Use padStart function

### DIFF
--- a/src/Components/Files/File Operation/trash.ts
+++ b/src/Components/Files/File Operation/trash.ts
@@ -78,7 +78,7 @@ const Restore = (filePath: string): void => {
 	);
 };
 
-const pad = (number: number) => (number < 10 ? '0' + number : number);
+const pad = (number: number) => number.toString().padStart(2, 0);
 
 const getDeletionDate = (date: Date) =>
 	date.getFullYear() +


### PR DESCRIPTION
## Motivation

I was looking through the code trying to figure out where the context menu is so that when you delete a file or folder it closes the context menu then I found this

## Changes

I changed the pad function to use the built in padStart function