### PR TITLE
Added slide selection and fixed image overflow for small screen sizes

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -160,6 +160,10 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
     width: 100%;
 }
 
+.features--list > .col--4 > img {
+	object-fit: contain;
+}
+
 @media only screen and (max-width: 996px) {
     .built-with-web h1 {
         font-size: 2rem;
@@ -229,6 +233,10 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
     border-radius: 50%;
     display: inline-block;
     transition: background-color 0.6s ease;
+	
+	/* Removing button styling */
+	cursor: pointer;
+	border: none;
 }
 
 .slide-dot.active {

--- a/docs/src/pages/index.jsx
+++ b/docs/src/pages/index.jsx
@@ -14,6 +14,7 @@ export default function Home() {
 						<h1 className="banner--title">File Explorer.</h1>
 						<h1 className="banner--subtitle">Redefined.</h1>
 						<h2 className="banner--description">Free and Open Source Software. Runs everywhere.</h2>
+
 						<div className="padding-top--l padding-bottom--l">
 							<a className="btn margin--sm" href="https://github.com/kimlimjustin/xplorer/releases" target="_blank">
 								Download now
@@ -23,14 +24,17 @@ export default function Home() {
 							</Link>
 						</div>
 					</div>
+
 					<div className="col col--8">
 						<Slideshow />
 					</div>
 				</div>
+
 				<div className="padding-top--xl built-with-web padding-bottom--xl">
 					<h1>
 						Cross-platform File Explorer. <em>Powered by the web.</em>
 					</h1>
+
 					<span>
 						Built using the{' '}
 						<a href="https://tauri.studio" target="_blank">
@@ -46,17 +50,20 @@ export default function Home() {
 						</a>{' '}
 						for the backend, Xplorer promises you an unprecedented experience.
 					</span>
+
 					<div className="row padding-top--xl features--list">
 						<div className="col col--4 padding-left--m padding-right--m">
 							<img src="/img/home/designed-out-of-the-box.png" alt="Xplorer designed out of the box" />
 							<h2>Designed out of the box</h2>
 							<p>Say goodbye to the old design by traditional app and say hello to this simple yet powerful design.</p>
 						</div>
+
 						<div className="col col--4 padding-left--m padding-right--m">
 							<img src="/img/home/support-tabs.png" alt="Support tabs" />
 							<h2>Supports Multiple Tabs</h2>
 							<p>Xplorer helps you organize you files easier by supporting multiple tabs .</p>
 						</div>
+
 						<div className="col col--4 padding-left--m padding-right--m">
 							<img src="/img/home/preview-files.png" alt="" />
 							<h2>File Preview</h2>

--- a/docs/src/pages/slideshow.jsx
+++ b/docs/src/pages/slideshow.jsx
@@ -33,30 +33,52 @@ const slides = [
 	},
 ];
 
+const SLIDE_INTERVAL = 2500;
+
 export default function Slideshow() {
 	const [index, setIndex] = useState(0);
+	const [handle, setHandle] = useState(null);
+
+	const destroyIntervalTimer = () => {
+		clearInterval(handle);
+		setHandle(null);
+	};
+
+	const createIntervalTimer = () => {
+		destroyIntervalTimer();
+		setHandle(setInterval(() => setIndex((i) => (i + 1) % slides.length), SLIDE_INTERVAL));
+	};
+
+	const handleSlideSelect = (idx) => {
+		createIntervalTimer();
+		setIndex(idx);
+	};
+
 	useEffect(() => {
-		const handle = setInterval(() => setIndex((i) => (i + 1) % slides.length), 2500);
-		return () => clearInterval(handle);
+		createIntervalTimer();
+		return destroyIntervalTimer;
 	}, []);
+
 	return (
-		<>
+		<div>
 			<div className="slideshow-container">
 				{slides.map((e, i) => (
 					<div key={i} className={`slide${index === i ? ' active' : ''}`}>
 						<div className="slide-numbertext">
 							{i + 1} / {slides.length}
 						</div>
+
 						<img src={e.src} alt={e.alt} />
-						<div className="slide-caption">{e.name}</div>
+						<p className="slide-caption">{e.name}</p>
 					</div>
 				))}
 			</div>
+
 			<div className="slide-dots">
-				{slides.map((e, i) => {
-					return <span key={e.name} className={`slide-dot${i === index ? ' active' : ''}`} />;
-				})}
+				{slides.map((e, i) => (
+					<button type="button" onClick={() => handleSlideSelect(i)} key={e.name} className={`slide-dot${i === index ? ' active' : ''}`} />
+				))}
 			</div>
-		</>
+		</div>
 	);
 }


### PR DESCRIPTION
## Motivation

This PR was created to improve the professionalism of the documentation site.

## Changes

### Updated docs image slideshow buttons

Updated the `docs/src/pages/slideshow.jsx` component to support user-selecting specific images within the slideshow. Previously users had to wait until the slideshow cycled to re-view an image. Now users can simply click on the dot corresponding to their desired image and that image will show. Note that after clicking on a dot the image will still cycle after a given period of time (configured in the component).

![image](https://user-images.githubusercontent.com/46639306/143302947-0c587a58-ffd9-4913-aeb9-f9f1e253f61c.png)
_These buttons can now be used to view specific images within the slideshow_

### Fixed small-screen docs image display

Currently images within the docs homepage (`docs/src/pages/index.jsx`) do not display properly on small screens. This was fixed using the `object-fit` [CSS rule](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit).

![image](https://user-images.githubusercontent.com/46639306/143303150-bb430850-9cd8-4e48-b6be-187164dc1033.png)
_Broken small-screen images_

![image](https://user-images.githubusercontent.com/46639306/143303089-d16ff2c6-7767-4632-be56-e7eafae92321.png)
_Fixed small-screen images_

## Related

No related PRs. No required documentation updates.

## Additional Comments

No additional comments.


<a href="https://gitpod.io/#https://github.com/kimlimjustin/xplorer/pull/180"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

