### PR TITLE
feat: sort files by name using locale compare(#196)

### DIFF
--- a/src/Components/Open/displayFiles.ts
+++ b/src/Components/Open/displayFiles.ts
@@ -29,14 +29,14 @@ const displayFiles = async (
 	const dirAlongsideFiles = preference?.dirAlongsideFiles ?? false;
 	const layout = (await Storage.get('layout'))?.[dir] ?? appearance?.layout ?? 'd';
 	const sort = (await Storage.get('sort'))?.[dir] ?? (await getDefaultSort(dir)) ?? 'A';
-	if (sort === 'A' || sort === 'Z') {
-		const compator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' }).compare;
+	const compator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' }).compare;
+	if (sort === 'A') {
 		files.sort((a, b) => {
-			if (sort === 'A') {
-				return compator(a.basename.toLowerCase(), b.basename.toLowerCase());
-			} else {
-				return compator(b.basename.toLowerCase(), a.basename.toLowerCase());
-			}
+			return compator(a.basename.toLowerCase(), b.basename.toLowerCase());
+		});
+	} else if (sort === 'Z') {
+		files.sort((a, b) => {
+			return compator(b.basename.toLowerCase(), a.basename.toLowerCase());
 		});
 	} else {
 		files = files.sort((a, b) => {

--- a/src/Components/Open/displayFiles.ts
+++ b/src/Components/Open/displayFiles.ts
@@ -1,4 +1,3 @@
-import { OpenLog } from '../Functions/log';
 import Storage from '../../Api/storage';
 import fileThumbnail from '../Thumbnail/thumbnail';
 import formatBytes from '../Functions/filesize';
@@ -29,28 +28,36 @@ const displayFiles = async (
 	const appearance = await Storage.get('appearance');
 	const dirAlongsideFiles = preference?.dirAlongsideFiles ?? false;
 	const layout = (await Storage.get('layout'))?.[dir] ?? appearance?.layout ?? 'd';
-	const sort = (await Storage.get('sort'))?.[dir] ?? (await getDefaultSort(dir)) ?? 'a';
-
-	files = files.sort((a, b) => {
-		switch (sort) {
-			case 'A': // A-Z
-				return a.basename.toLowerCase() > b.basename.toLowerCase() ? 1 : -1;
-			case 'Z': // Z-A
-				return a.basename.toLowerCase() < b.basename.toLowerCase() ? 1 : -1;
-			case 'L': // Last Modified
-				return new Date(a.last_modified?.secs_since_epoch ?? a.time_deleted) < new Date(b.last_modified?.secs_since_epoch ?? b.time_deleted)
-					? 1
-					: -1;
-			case 'F': // First Modified
-				return new Date(a.last_modified?.secs_since_epoch ?? a.time_deleted) > new Date(b.last_modified?.secs_since_epoch ?? b.time_deleted)
-					? 1
-					: -1;
-			case 'S': // Size
-				return a.size > b.size ? 1 : -1;
-			case 'T':
-				return a.file_type > b.file_type ? 1 : -1;
-		}
-	});
+	const sort = (await Storage.get('sort'))?.[dir] ?? (await getDefaultSort(dir)) ?? 'A';
+	if (sort === 'A' || sort === 'Z') {
+		const compator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' }).compare;
+		files.sort((a, b) => {
+			if (sort === 'A') {
+				return compator(a.basename.toLowerCase(), b.basename.toLowerCase());
+			} else {
+				return compator(b.basename.toLowerCase(), a.basename.toLowerCase());
+			}
+		});
+	} else {
+		files = files.sort((a, b) => {
+			switch (sort) {
+				case 'L': // Last Modified
+					return new Date(a.last_modified?.secs_since_epoch ?? a.time_deleted) <
+						new Date(b.last_modified?.secs_since_epoch ?? b.time_deleted)
+						? 1
+						: -1;
+				case 'F': // First Modified
+					return new Date(a.last_modified?.secs_since_epoch ?? a.time_deleted) >
+						new Date(b.last_modified?.secs_since_epoch ?? b.time_deleted)
+						? 1
+						: -1;
+				case 'S': // Size
+					return a.size > b.size ? 1 : -1;
+				case 'T':
+					return a.file_type > b.file_type ? 1 : -1;
+			}
+		});
+	}
 	if (!dirAlongsideFiles) {
 		files = files.sort((a, b) => -(Number(a.is_dir) - Number(b.is_dir)));
 	}

--- a/src/Components/Open/displayFiles.ts
+++ b/src/Components/Open/displayFiles.ts
@@ -28,20 +28,18 @@ const displayFiles = async (
 	const appearance = await Storage.get('appearance');
 	const dirAlongsideFiles = preference?.dirAlongsideFiles ?? false;
 	const layout = (await Storage.get('layout'))?.[dir] ?? appearance?.layout ?? 'd';
-	const sort = (await Storage.get('sort'))?.[dir] ?? await getDefaultSort(dir);
+	const sort = (await Storage.get('sort'))?.[dir] ?? (await getDefaultSort(dir));
 	switch (sort) {
 		case 'L': // Last Modified
 			files.sort((a, b) => {
-				return new Date(a.last_modified?.secs_since_epoch ?? a.time_deleted) <
-					new Date(b.last_modified?.secs_since_epoch ?? b.time_deleted)
+				return new Date(a.last_modified?.secs_since_epoch ?? a.time_deleted) < new Date(b.last_modified?.secs_since_epoch ?? b.time_deleted)
 					? 1
 					: -1;
 			});
 			break;
 		case 'F': // First Modified
 			files.sort((a, b) => {
-				return new Date(a.last_modified?.secs_since_epoch ?? a.time_deleted) >
-					new Date(b.last_modified?.secs_since_epoch ?? b.time_deleted)
+				return new Date(a.last_modified?.secs_since_epoch ?? a.time_deleted) > new Date(b.last_modified?.secs_since_epoch ?? b.time_deleted)
 					? 1
 					: -1;
 			});
@@ -50,7 +48,7 @@ const displayFiles = async (
 			files.sort((a, b) => a.size - b.size);
 			break;
 		case 'T': // Filetype
-			files.sort((a, b) => a.file_type - b.file_type);
+			files.sort((a, b) => (a.file_type > b.file_type ? 1 : -1));
 			break;
 
 		case 'A': // A-Z


### PR DESCRIPTION
## Motivation

The current sort method is by brutally sorting it alphabetically, this PR intended to make it more humanly by adding feature to automatically sort the file by parsing locale information from the file name and sort it using `localeCompare`.

## Changes

- Use `Intl.Collator` to compare file names

## Related

Requested on #196

## Additional Comments

@uahnbu Could you please review this PR? does this PR works well as you expected? 


<a href="https://gitpod.io/#https://github.com/kimlimjustin/xplorer/pull/198"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

