### PR TITLE
Fix: at function is not defined on macos, resulting in theme not working on macos

### DIFF
--- a/src/Components/Theme/theme.ts
+++ b/src/Components/Theme/theme.ts
@@ -87,7 +87,6 @@ const changeTheme = async (theme?: string, category?: '*' | 'root' | 'tabbing' |
 	if (!category) category = '*';
 	const appearance = await Storage.get('appearance');
 	if (category === '*' || category === 'root') {
-		1;
 		document.body.style.setProperty('--edge-radius', appearance?.frameStyle === 'os' ? '0px' : '10px');
 		document.body.style.fontSize = appearance?.fontSize ?? '16px';
 		document.documentElement.style.fontSize = appearance?.fontSize ?? '16px';
@@ -131,12 +130,12 @@ const changeTheme = async (theme?: string, category?: '*' | 'root' | 'tabbing' |
 		const style = document.querySelector('style#root') ?? document.createElement('style');
 		style.id = 'root';
 		let styles = '';
-
 		// Generate CSS styles from user theme
 		for (const key of Object.keys(themeJSON ?? defaultThemeJSON[theme])) {
 			const value = themeJSON ? themeJSON[key] : defaultThemeJSON[theme]?.[key];
 			const formalKey = key.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase());
-			const styleKey = formalKey.split('.').at(-1);
+			const splittedKey = formalKey.split('.')
+			const styleKey =splittedKey[splittedKey.length - 1];
 			if (key.startsWith('hljs')) {
 				const className = formalKey.split('.').slice(0, -1).join('.').replace('hljs.', 'hljs-');
 				styles += `.${className} { ${styleKey}: ${value}; }\n`;


### PR DESCRIPTION
The Xplorer theme on macOS was transparent and not working. This was caused by the `changeTheme()` function.
Image of the Problem:
![image](https://user-images.githubusercontent.com/71512866/147816284-c84aa418-e132-4230-87da-40e46702bc66.png)
