### PR TITLE
feat: using bincode to serialize/deserialize storage data

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -42,6 +42,7 @@ checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
 name = "app"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "clap",
  "font-loader",
  "glob",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ parselnk = "0.1.0"
 url = "2.2.2"
 reqwest = "0.11.8"
 tokio = {version="1.14", features = ["full"] }
+bincode = {version="1.3.3"}
 
 [target."cfg(any(target_os = \"windows\", target_os = \"macos\"))".dependencies]
 tauri-plugin-vibrancy = { git = "https://github.com/tauri-apps/tauri-plugin-vibrancy", features = ["tauri-impl"] }


### PR DESCRIPTION
## Motivation
The current approach to writing down users' preference settings is by writing in text format, as a result, it's easy to be read by other applications leading to security concerns.  This PR intended to make it a little bit "harder" by using `bincode` serialize and deserialize method. 

## Changes

* add `bincode` dependency
* use `bincode` to serialize/deserialize storage data



<a href="https://gitpod.io/#https://github.com/kimlimjustin/xplorer/pull/216"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

