### PR TITLE
refactor: use `encodeURI` and `decodeURI` instead of `escape` and `unescape`

### DIFF
--- a/src/Components/ContextMenu/configs/bodyMenu.config.ts
+++ b/src/Components/ContextMenu/configs/bodyMenu.config.ts
@@ -170,7 +170,7 @@ const BodyMenu = async (target: HTMLElement, filePath: string): Promise<contextM
 				visible: _focusingPath === 'xplorer://Trash',
 				icon: 'delete',
 				role: () => {
-					const filePaths = [...document.querySelectorAll<HTMLElement>('.file')].map((file) => unescape(file.dataset.path));
+					const filePaths = [...document.querySelectorAll<HTMLElement>('.file')].map((file) => decodeURI(file.dataset.path));
 					Restore(filePaths);
 				},
 			},
@@ -179,7 +179,7 @@ const BodyMenu = async (target: HTMLElement, filePath: string): Promise<contextM
 				visible: _focusingPath === 'xplorer://Trash',
 				icon: 'delete',
 				role: () => {
-					const filePaths = [...document.querySelectorAll<HTMLElement>('.file')].map((file) => unescape(file.dataset.path));
+					const filePaths = [...document.querySelectorAll<HTMLElement>('.file')].map((file) => decodeURI(file.dataset.path));
 					Purge(filePaths);
 				},
 			},

--- a/src/Components/ContextMenu/configs/fileMenu.config.ts
+++ b/src/Components/ContextMenu/configs/fileMenu.config.ts
@@ -109,7 +109,7 @@ const FileMenu = async (target: HTMLElement, filePath: string): Promise<contextM
 				icon: 'delete',
 				visible: _focusingPath === 'xplorer://Trash',
 				role: () => {
-					Restore([unescape(filePath)]);
+					Restore([decodeURI(filePath)]);
 				},
 			},
 			{
@@ -118,7 +118,7 @@ const FileMenu = async (target: HTMLElement, filePath: string): Promise<contextM
 				visible: _focusingPath === 'xplorer://Trash',
 				shortcut: 'Shift+Del',
 				role: () => {
-					Purge([unescape(filePath)]);
+					Purge([decodeURI(filePath)]);
 				},
 			},
 			{

--- a/src/Components/ContextMenu/configs/multipleSelectedMenu.config.ts
+++ b/src/Components/ContextMenu/configs/multipleSelectedMenu.config.ts
@@ -19,7 +19,7 @@ const MultipleSelectedMenu = async (_: HTMLElement, _filePath: string): Promise<
 				role: () => {
 					for (const element of getSelected()) {
 						if (element.dataset.isdir === 'true') {
-							createNewTab(unescape(element.dataset.path));
+							createNewTab(decodeURI(element.dataset.path));
 						}
 					}
 				},
@@ -29,7 +29,7 @@ const MultipleSelectedMenu = async (_: HTMLElement, _filePath: string): Promise<
 				menu: await Translate('Open in VSCode'),
 				role: () => {
 					for (const selected of getSelected()) {
-						const targetPath = unescape(selected.dataset.path) === 'undefined' ? _focusingPath : unescape(selected.dataset.path);
+						const targetPath = decodeURI(selected.dataset.path) === 'undefined' ? _focusingPath : decodeURI(selected.dataset.path);
 						reveal(targetPath, 'vscode');
 					}
 				},
@@ -46,7 +46,7 @@ const MultipleSelectedMenu = async (_: HTMLElement, _filePath: string): Promise<
 				role: () => {
 					const paths = [];
 					for (const element of getSelected()) {
-						paths.push(unescape(element.dataset.path));
+						paths.push(decodeURI(element.dataset.path));
 					}
 					Cut(paths);
 				},
@@ -58,7 +58,7 @@ const MultipleSelectedMenu = async (_: HTMLElement, _filePath: string): Promise<
 				role: () => {
 					const paths = [];
 					for (const element of getSelected()) {
-						paths.push(unescape(element.dataset.path));
+						paths.push(decodeURI(element.dataset.path));
 					}
 					Copy(paths);
 				},
@@ -70,7 +70,7 @@ const MultipleSelectedMenu = async (_: HTMLElement, _filePath: string): Promise<
 				role: () => {
 					const paths = [];
 					for (const element of getSelected()) {
-						paths.push(unescape(element.dataset.path));
+						paths.push(decodeURI(element.dataset.path));
 					}
 					Trash(paths);
 				},
@@ -84,7 +84,7 @@ const MultipleSelectedMenu = async (_: HTMLElement, _filePath: string): Promise<
 				role: () => {
 					const filePaths = [];
 					for (const element of getSelected()) {
-						filePaths.push(unescape(element.dataset.path));
+						filePaths.push(decodeURI(element.dataset.path));
 					}
 					Restore(filePaths);
 				},
@@ -96,7 +96,7 @@ const MultipleSelectedMenu = async (_: HTMLElement, _filePath: string): Promise<
 				role: () => {
 					const filePaths = [];
 					for (const element of getSelected()) {
-						filePaths.push(unescape(element.dataset.path));
+						filePaths.push(decodeURI(element.dataset.path));
 					}
 					Purge(filePaths);
 				},
@@ -110,7 +110,7 @@ const MultipleSelectedMenu = async (_: HTMLElement, _filePath: string): Promise<
 				role: () => {
 					const paths = [];
 					for (const element of getSelected()) {
-						paths.push(unescape(element.dataset.path));
+						paths.push(decodeURI(element.dataset.path));
 					}
 					Pin(paths);
 				},

--- a/src/Components/ContextMenu/contextMenu.ts
+++ b/src/Components/ContextMenu/contextMenu.ts
@@ -123,7 +123,7 @@ const ContextMenu = (): void => {
 		}
 		if (!target?.dataset?.path) return;
 
-		const filePath = unescape(target.dataset.path);
+		const filePath = decodeURI(target.dataset.path);
 
 		// Create the context menu
 		if (getSelected().length > 1) {

--- a/src/Components/Drives/drives.ts
+++ b/src/Components/Drives/drives.ts
@@ -28,7 +28,7 @@ const drivesToElements = async (drives: Drive[]): Promise<string> => {
 	for (const drive of drives) {
 		const driveName = drive.mount_point.split('/')[drive.mount_point.split('/').length - 1]; // Get name of drive
 		result += `
-        <div class="pendrive file card-hover-effect" data-isdir="true" data-path = "${escape(drive.mount_point)}">
+        <div class="pendrive file card-hover-effect" data-isdir="true" data-path = "${encodeURI(drive.mount_point)}">
             <img src="${await fileThumbnail(drive.is_removable ? 'usb' : 'hard-disk', 'favorites', false)}" alt="USB icon" class="pendrive-icon">
             <div class="pendrive-info">
                 ${
@@ -88,7 +88,7 @@ const writeSidebarDriveItems = async (): Promise<void> => {
 		const driveType = drive.is_removable ? 'usb' : 'hard-disk';
 		const iconPath = await fileThumbnail(driveType, 'favorites', false);
 		content +=
-			`<span data-path="${escape(drive.mount_point)}" data-isdir="true" class="sidebar-hover-effect sidebar-nav-item drive-item">\n` +
+			`<span data-path="${encodeURI(drive.mount_point)}" data-isdir="true" class="sidebar-hover-effect sidebar-nav-item drive-item">\n` +
 			`  <div class="sidebar-icon">\n` +
 			`    <img src="${iconPath}">\n` +
 			`  </div>\n` +

--- a/src/Components/Files/File Operation/cut.ts
+++ b/src/Components/Files/File Operation/cut.ts
@@ -8,7 +8,7 @@ import Storage from '../../../Service/storage';
 const Cut = (files: Array<string>): void => {
 	Storage.set('clipboard', { command: 'cut', files: files });
 	for (const file of files) {
-		document.querySelector(`.file[data-path="${escape(file)}"]`).classList.add('cut');
+		document.querySelector(`.file[data-path="${encodeURI(file)}"]`).classList.add('cut');
 	}
 
 	(async function detectClipboardChange() {
@@ -16,7 +16,7 @@ const Cut = (files: Array<string>): void => {
 		if ((await Storage.get('clipboard')).files !== files) {
 			global.clearTimeout(n);
 			document.querySelectorAll<HTMLElement>('.file.cut').forEach((file) => {
-				if (files.indexOf(unescape(file.dataset.path)) !== -1) {
+				if (files.indexOf(decodeURI(file.dataset.path)) !== -1) {
 					file.classList.remove('cut');
 				}
 			});

--- a/src/Components/Files/File Operation/location.ts
+++ b/src/Components/Files/File Operation/location.ts
@@ -6,7 +6,7 @@ import { writeTextToClipboard } from '../../../Service/clipboard';
  * @returns {void}
  */
 const copyLocation = (element: HTMLElement): void => {
-	const path = unescape(element.dataset.path);
+	const path = decodeURI(element.dataset.path);
 	writeTextToClipboard(path);
 };
 

--- a/src/Components/Files/File Operation/rename.ts
+++ b/src/Components/Files/File Operation/rename.ts
@@ -25,7 +25,7 @@ const Rename = (filePath: string): void => {
 		} catch (err) {
 			PromptError('Error renaming file', `Failed to rename ${filePath} [${err}]`);
 		}
-		OperationLog('rename', unescape(filePath), target);
+		OperationLog('rename', decodeURI(filePath), target);
 	});
 };
 

--- a/src/Components/Files/File Operation/select.ts
+++ b/src/Components/Files/File Operation/select.ts
@@ -17,7 +17,7 @@ const ChangeSelectedEvent = async (): Promise<void> => {
 	const selectedFileGrid = document.querySelectorAll('.file-grid.selected');
 	if (!selectedFileGrid.length) UpdateInfo('selected-files', '');
 	else {
-		const selectedFilePaths = Array.from(selectedFileGrid).map((element) => unescape((element as HTMLElement).dataset.path));
+		const selectedFilePaths = Array.from(selectedFileGrid).map((element) => decodeURI((element as HTMLElement).dataset.path));
 		const total_sizes = await new FileAPI(selectedFilePaths).calculateFilesSize();
 		UpdateInfo('selected-files', `${selectedFileGrid.length} file${selectedFileGrid.length > 1 ? 's' : ''} selected ${formatBytes(total_sizes)}`);
 		if (

--- a/src/Components/Functions/changePosition.ts
+++ b/src/Components/Functions/changePosition.ts
@@ -12,7 +12,7 @@ import { UpdateInfo } from '../Layout/infobar';
  */
 const changePosition = async (newPath: string, forceChange = false): Promise<void> => {
 	document.querySelector<HTMLInputElement>('.path-navigator').value = newPath;
-	document.getElementById('workspace').dataset.path = escape(newPath);
+	document.getElementById('workspace').dataset.path = encodeURI(newPath);
 
 	const tabs = await Storage.get(`tabs-${windowName}`);
 	const _focusingTab = tabs?.tabs[String(tabs?.focus)];

--- a/src/Components/Layout/hover.ts
+++ b/src/Components/Layout/hover.ts
@@ -49,7 +49,7 @@ const Hover = (): void => {
 
 		timeOut = window.setTimeout(async () => {
 			displayName = filenameGrid.innerHTML;
-			const path = unescape(target.dataset.path);
+			const path = decodeURI(target.dataset.path);
 			filenameGrid.innerHTML = isOnSearch ? path : getBasename(path);
 			target?.classList?.add('hovering');
 

--- a/src/Components/Open/displayFiles.ts
+++ b/src/Components/Open/displayFiles.ts
@@ -114,7 +114,7 @@ const displayFiles = async (
 		}
 		fileGrid.dataset.isdir = String(file.is_dir);
 		if (file.time_deleted) fileGrid.dataset.trashDeletionDate = String(file.time_deleted);
-		if (file.is_trash) fileGrid.dataset.realPath = escape(joinPath(file.original_parent, file.basename));
+		if (file.is_trash) fileGrid.dataset.realPath = encodeURI(joinPath(file.original_parent, file.basename));
 		let preview: string;
 		if (file.file_type === 'Windows Shortcut') {
 			fileGrid.dataset.isLnk = 'true';
@@ -128,7 +128,7 @@ const displayFiles = async (
 			preview = await fileThumbnail(file.file_path, file.is_dir ? 'folder' : 'file', true, imageAsThumbnail);
 		}
 
-		fileGrid.dataset.path = escape(normalizeSlash(file.file_path));
+		fileGrid.dataset.path = encodeURI(normalizeSlash(file.file_path));
 		fileGrid.dataset.isSystem = String(file.is_system);
 		fileGrid.dataset.isTrash = String(file.is_trash);
 		fileGrid.dataset.isDir = String(file.is_dir);
@@ -154,7 +154,7 @@ const displayFiles = async (
 		FilesElement.appendChild(fileGrid);
 	}
 	if (options?.reveal) {
-		Select(document.querySelector<HTMLElement>(`.file[data-path="${escape(options?.revealDir)}"]`), false, false);
+		Select(document.querySelector<HTMLElement>(`.file[data-path="${encodeURI(options?.revealDir)}"]`), false, false);
 	}
 
 	return FilesElement;

--- a/src/Components/Open/open.ts
+++ b/src/Components/Open/open.ts
@@ -181,7 +181,7 @@ const OpenHandler = async (e: MouseEvent): Promise<void> => {
 	if (!element?.dataset?.path) return;
 	if (element.id === 'workspace') return;
 
-	const filePath = unescape(element.dataset.path);
+	const filePath = decodeURI(element.dataset.path);
 
 	// Open the file if it's not directory
 	if (element.dataset.isdir !== 'true') {

--- a/src/Components/Open/recent.ts
+++ b/src/Components/Open/recent.ts
@@ -105,7 +105,7 @@ const Recent = async (): Promise<void> => {
 			}
 			fileGrid.setAttribute('draggable', 'true');
 			fileGrid.dataset.isdir = String(recent.properties.is_dir);
-			fileGrid.dataset.path = escape(NormalizeSlash(recent.path));
+			fileGrid.dataset.path = encodeURI(NormalizeSlash(recent.path));
 			fileGrid.dataset.isSystem = String(recent.properties.is_system);
 			fileGrid.dataset.isReadOnly = String(recent.properties.readonly);
 			fileGrid.dataset.isHidden = String(recent.properties.is_hidden);

--- a/src/Components/Properties/properties.ts
+++ b/src/Components/Properties/properties.ts
@@ -32,7 +32,7 @@ const RenderProperties = (options: Record<string, unknown>) => {
  * @returns {void}
  */
 const Properties = (filePath: string): void => {
-	const fileElement = document.querySelector<HTMLElement>(`[data-path="${escape(filePath)}"]`);
+	const fileElement = document.querySelector<HTMLElement>(`[data-path="${encodeURI(filePath)}"]`);
 
 	const size = fileElement.querySelector('.file-size').innerHTML;
 	if (fileElement.dataset.realPath) filePath = fileElement.dataset.realPath;

--- a/src/Components/Shortcut/shortcut.ts
+++ b/src/Components/Shortcut/shortcut.ts
@@ -120,14 +120,14 @@ const Shortcut = (): void => {
 		searchElement.placeholder = '🔎 Search';
 
 		const selectedFile = getSelected()?.[0];
-		const selectedFilePath = unescape(selectedFile?.dataset?.path);
+		const selectedFilePath = decodeURI(selectedFile?.dataset?.path);
 		const isDir = selectedFile?.dataset.isdir === 'true';
 		const _focusingPath = await focusingPath();
 
 		// Open file shorcut (Enter)
 		if (e.key === 'Enter') {
 			for (const selected of getSelected()) {
-				const targetPath = unescape(selected.dataset.path) === 'undefined' ? _focusingPath : unescape(selected.dataset.path);
+				const targetPath = decodeURI(selected.dataset.path) === 'undefined' ? _focusingPath : decodeURI(selected.dataset.path);
 				if ((await new DirectoryAPI(targetPath).exists()) && !pauseEnterListener) {
 					// Open file in vscode (Shift + Enter)
 					if (e.shiftKey) {
@@ -177,7 +177,7 @@ const Shortcut = (): void => {
 		else if (e.altKey && e.key === 'p') {
 			let filePaths = [];
 			for (const element of getSelected()) {
-				filePaths.push(unescape(element.dataset.path));
+				filePaths.push(decodeURI(element.dataset.path));
 			}
 			if (!filePaths.length) filePaths = [_focusingPath];
 			Pin(filePaths);
@@ -187,7 +187,7 @@ const Shortcut = (): void => {
 		else if (e.ctrlKey && e.key === 'c') {
 			const filePaths = [];
 			for (const element of getSelected()) {
-				filePaths.push(unescape(element.dataset.path));
+				filePaths.push(decodeURI(element.dataset.path));
 			}
 			Copy(filePaths);
 		}
@@ -231,7 +231,7 @@ const Shortcut = (): void => {
 		else if (e.ctrlKey && e.key === 'x') {
 			const filePaths = [];
 			for (const element of getSelected()) {
-				filePaths.push(unescape(element.dataset.path));
+				filePaths.push(decodeURI(element.dataset.path));
 			}
 			Cut(filePaths);
 		}
@@ -273,7 +273,7 @@ const Shortcut = (): void => {
 			if (e.shiftKey) {
 				const filePaths = [];
 				for (const element of getSelected()) {
-					filePaths.push(unescape(element.dataset.path));
+					filePaths.push(decodeURI(element.dataset.path));
 				}
 				if (_focusingPath === 'xplorer://Trash') Purge(filePaths);
 				else PermanentDelete(filePaths);
@@ -281,7 +281,7 @@ const Shortcut = (): void => {
 				if (_focusingPath === 'xplorer://Trash') return;
 				const filePaths = [];
 				for (const element of getSelected()) {
-					filePaths.push(unescape(element.dataset.path));
+					filePaths.push(decodeURI(element.dataset.path));
 				}
 				Trash(filePaths);
 			}
@@ -304,7 +304,7 @@ const Shortcut = (): void => {
 		else if (e.ctrlKey && e.key === 'p') {
 			e.preventDefault();
 			const selectedFile = getSelected()?.[0];
-			const selectedFilePath = unescape(selectedFile?.dataset?.path);
+			const selectedFilePath = decodeURI(selectedFile?.dataset?.path);
 			Properties(selectedFilePath === 'undefined' ? await focusingPath() : selectedFilePath);
 		}
 		// Find files (Ctrl+F)


### PR DESCRIPTION
## Motivation
`escape` and `unescape` have been deprecated and are not recommended to be used again. 

Ref: https://stackoverflow.com/questions/75980/when-are-you-supposed-to-use-escape-instead-of-encodeuri-encodeuricomponent

## Changes
- replace `escape` and `unescape` with `encodeURI` and `decodeURI`.

## Related

- https://github.com/kimlimjustin/xplorer/pull/225#pullrequestreview-866334386
- https://262.ecma-international.org/9.0/#sec-escape-string


@uahnbu could you please review this?

<a href="https://gitpod.io/#https://github.com/kimlimjustin/xplorer/pull/226"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

