### PR TITLE
Removed unused import

### DIFF
--- a/api/web/src/main.rs
+++ b/api/web/src/main.rs
@@ -12,6 +12,7 @@ use font_loader::system_fonts;
 use std::collections::HashMap;
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
+#[cfg(target_os = "windows")]
 use std::process::Command;
 
 #[derive(serde::Serialize, Clone, Debug)]


### PR DESCRIPTION
## Motivation
I had fun doing it.

## Changes
Removed unused import under linux. The import is only used under windows.


<a href="https://gitpod.io/#https://github.com/kimlimjustin/xplorer/pull/235"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

