### PR TITLE
Fix tab hover effect flickering when hover tab title

### DIFF
--- a/src/Components/Theme/theme.ts
+++ b/src/Components/Theme/theme.ts
@@ -70,7 +70,7 @@ const hoverHandler = (obj: HTMLElement, theme: string, type: ElementType) => {
 	if (obj.getAttribute('being-listened') === 'true') return;
 	obj.setAttribute('being-listened', 'true');
 	obj.addEventListener('mousemove', (e) => {
-		const rect = (e.target as HTMLElement).getBoundingClientRect();
+		const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
 		const x = e.clientX - rect.left;
 		const y = e.clientY - rect.top;
 		if (obj.classList.contains('active')) return (obj.onmouseleave = null);


### PR DESCRIPTION
## Motivation

https://github.com/kimlimjustin/xplorer/issues/252

## Changes

Change e.target to e.currentTarget, so effect coordinates would be calculated from the parent tab element, and not the hovered child elements like title, or close button.



<a href="https://gitpod.io/#https://github.com/kimlimjustin/xplorer/pull/253"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

