### PR TITLE
Tauri does use OS specific webview

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Simply close and reopen Xplorer, Xplorer will fix itself. If it doesn't, please 
 
 ## Architecture
 
-Xplorer is a cross-platform application built using the [Tauri](https://tauri.studio) framework. Tauri is based on Microsoft Edge-similar webview and Rust to work. Read about tauri [here](https://tauri.studio/en/docs/about/intro)
+Xplorer is a cross-platform application built using the [Tauri](https://tauri.studio) framework. Tauri is based on the OS specific webview and Rust to work. Read about tauri [here](https://tauri.studio/en/docs/about/intro)
 
 Xplorer is a polygot application. Xplorer relies on Rust api for file operations and TS, SCSS for the webview. Rust code are under `src-tauri` directory whereas the webview code are under `src` directory. The API that connects webview with the Rust code is under `src/Api` directory.
 


### PR DESCRIPTION
Tauri does not use Microsoft Edge on MacOS, Linux or any other platform.

## Motivation

(Write your motivation here.)

## Changes

(Write what things you changed)

## Related

(Optional, link(s) of related Issues or PR related to this PR, If this PR adds or changes functionality, please take some time to update the docs and link your PR here.)

## Additional Comments

(Anything, optional)


<a href="https://gitpod.io/#https://github.com/kimlimjustin/xplorer/pull/260"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

