### PR TITLE
Make mousemove event trigger on contextmenu-item instead of icon

### DIFF
--- a/src/Components/ContextMenu/contextMenu.scss
+++ b/src/Components/ContextMenu/contextMenu.scss
@@ -18,6 +18,7 @@
 			width: 1rem;
 			vertical-align: middle;
 			margin-right: 1rem;
+			pointer-events: none;
 		}
 
 		.contextmenu-item-shortcut {


### PR DESCRIPTION
## Motivation

[#281](https://github.com/kimlimjustin/xplorer/issues/281)

## Changes

Add `pointer-events:none` for context menu icon.
Even when mouse stays on the icon, mousemove event still can trigger on contextmenu-item so that submenu will not disappear.
