### PR TITLE
refactor(redux, types): use typed dispatch and selector

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
 
 import MainView from "./Components/MainView";
 import SettingsView from "./Components/SettingsView";
@@ -13,16 +12,16 @@ import Infobar from "./Components/Infobar";
 import OperationBar from "./Components/OperationBar";
 
 import { setActiveTab } from "./Store/ActionCreators/TabActionCreators";
-import { IAppState } from "./Store/Reducers";
+import { useAppDispatch, useAppSelector } from "./Store/Hooks";
 import "./Public/style.scss";
 import { ThemedDiv } from "./Components/Theme";
 
 const App = () => {
-    const dispatch = useDispatch();
+    const dispatch = useAppDispatch();
 
-    const homeDirectory = useSelector<IAppState, IAppState["favorites"]["Home"]>((state) => state.favorites.Home);
-    const activeTab = useSelector<IAppState, IAppState["tabs"]["activeTab"]>((state) => state.tabs.activeTab);
-    const config = useSelector<IAppState, IAppState["config"]>((state) => state.config);
+    const homeDirectory = useAppSelector((state) => state.favorites.Home);
+    const activeTab = useAppSelector((state) => state.tabs.activeTab);
+    const config = useAppSelector((state) => state.config);
 
     const [isLoaded, setIsLoaded] = useState(false); // TODO REPLACE WITH SKELETON LOADING
 

--- a/src/Components/File/index.tsx
+++ b/src/Components/File/index.tsx
@@ -1,5 +1,4 @@
 import React, { MouseEvent } from "react";
-import { useDispatch, useSelector } from "react-redux";
 
 import GridFile from "./GridFile";
 import DetailFile from "./DetailFile";
@@ -7,7 +6,7 @@ import DetailFile from "./DetailFile";
 import { getStandardPath } from "../../Helpers/paths";
 import { openFileRequest, openFilePreview } from "../../Store/ActionCreators/FilesActionCreators";
 import { setActiveTab, updateTab } from "../../Store/ActionCreators/TabActionCreators";
-import { IAppState } from "../../Store/Reducers";
+import { useAppDispatch, useAppSelector } from "../../Store/Hooks";
 import FileMetaData from "../../Typings/fileMetaData";
 import { updateSelection } from "../../Store/ActionCreators/SelectionActionCreators";
 import { sortFiles } from "../MainView";
@@ -20,11 +19,11 @@ export interface IFileProps {
 }
 
 export const File = ({ mode, metadata }: IFileProps): JSX.Element => {
-    const dispatch = useDispatch();
-    const activeTab = useSelector<IAppState, IAppState["tabs"]["activeTab"]>((state) => state.tabs.activeTab);
-    const selected = useSelector<IAppState, IAppState["selection"]["selected"]>((state) => state.selection.selected);
-    const allFiles = useSelector<IAppState, IAppState["files"]["files"]>((state) => state.files.files);
-
+    const dispatch = useAppDispatch();
+    const activeTab = useAppSelector((state) => state.tabs.activeTab);
+    const selected = useAppSelector((state) => state.selection.selected);
+    const allFiles = useAppSelector((state) => state.files.files);
+    
     const handleFileSingleClick = (e: MouseEvent<HTMLButtonElement>, filePath: string) => {
         if (e.shiftKey) {
             const files = Object.values(allFiles).sort(sortFiles);

--- a/src/Components/Header/index.tsx
+++ b/src/Components/Header/index.tsx
@@ -1,14 +1,15 @@
-import React, { useEffect } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import React from "react";
 
 import SubHeader from "./SubHeader";
 import { getStandardPath } from "../../Helpers/paths";
 import { fetchFilesRequest, updateHistoryIdxRequest } from "../../Store/ActionCreators/DirectoryActionCreators";
 import { createTab, deleteTab, setActiveTab } from "../../Store/ActionCreators/TabActionCreators";
-import { IAppState } from "../../Store/Reducers";
+import { useAppDispatch, useAppSelector } from "../../Store/Hooks";
 import { ThemedButton, ThemedDiv, ThemedSpan } from "../Theme";
 import { closeWindowRequest, maximizeWindowRequest, minimizeWindowRequest } from "../../Store/ActionCreators/WindowActionCreators";
+
 let tabId = 0;
+
 export interface ITab {
     name: string;
     path: string;
@@ -16,11 +17,11 @@ export interface ITab {
 }
 
 const Header = () => {
-    const dispatch = useDispatch();
-    const homeDirectory = useSelector<IAppState, IAppState["favorites"]["Home"]>((state) => state.favorites.Home);
-    const tabs = useSelector<IAppState, IAppState["tabs"]["tabs"]>((state) => state.tabs.tabs);
-    const activeTab = useSelector<IAppState, IAppState["tabs"]["activeTab"]>((state) => state.tabs.activeTab);
-    const directoryHistoryIdx = useSelector<IAppState, IAppState["directory"]["historyIdx"]>((state) => state.directory.historyIdx);
+    const dispatch = useAppDispatch();
+    const homeDirectory = useAppSelector((state) => state.favorites.Home);
+    const tabs = useAppSelector((state) => state.tabs.tabs);
+    const activeTab = useAppSelector((state) => state.tabs.activeTab);
+    const directoryHistoryIdx = useAppSelector((state) => state.directory.historyIdx);
 
     const createNewTab = () => {
         const newTab = { name: "New Tab", path: homeDirectory, id: ++tabId };

--- a/src/Components/MainView/index.tsx
+++ b/src/Components/MainView/index.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect } from "react";
-import { useSelector } from "react-redux";
 
 import File from "../File";
 import Preview from "../Preview";
 
-import { IAppState } from "../../Store/Reducers";
+import { useAppSelector } from "../../Store/Hooks";
 import { IFile } from "../../Typings/Store/files";
 import { ThemedDiv } from "../Theme";
 
@@ -20,8 +19,8 @@ export const sortFiles = (a: IFile, b: IFile): number => {
 };
 
 const MainView = ({ currentDirectory }: IMainViewProps) => {
-    const files = useSelector<IAppState, IAppState["files"]["files"]>((state) => state.files.files);
-    const filePreview = useSelector<IAppState, IAppState["files"]["filePreview"]>((state) => state.files.filePreview);
+    const files = useAppSelector((state) => state.files.files);
+    const filePreview = useAppSelector((state) => state.files.filePreview);
 
     return (
         <ThemedDiv componentName="mainBox" className="main-box">

--- a/src/Components/Preview/PdfViewer.tsx
+++ b/src/Components/Preview/PdfViewer.tsx
@@ -1,36 +1,29 @@
-import React, { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React, { useEffect } from "react";
 
-import { readAssetRequest } from '../../Store/ActionCreators/FilesActionCreators';
-import { IAppState } from '../../Store/Reducers';
+import { readAssetRequest } from "../../Store/ActionCreators/FilesActionCreators";
+import { useAppDispatch, useAppSelector } from "../../Store/Hooks";
 
 export interface IPdfViewerProps {
-  filePath: string
+    filePath: string;
 }
 
 const PdfViewer = ({ filePath }: IPdfViewerProps): JSX.Element => {
-  const dispatch = useDispatch();
-  const content = useSelector<IAppState, any>(state => state.files.files?.[filePath]?.content);
+    const dispatch = useAppDispatch();
+    const content = useAppSelector((state) => state.files.files?.[filePath]?.content);
 
-  useEffect(() => {
-    dispatch(readAssetRequest(filePath));
-  }, [filePath]);
+    useEffect(() => {
+        dispatch(readAssetRequest(filePath));
+    }, [filePath]);
 
-  if (!content) return <div>Loading...</div>;
+    if (!content) return <div>Loading...</div>;
 
-  return (
-    <div id="pdf-preview-container">
-      <object
-        data={`${content}#toolbar=0&navpanes=1`}
-        type="application/pdf"
-        className="preview-object"
-      >
-        <embed
-          src={`${content}#toolbar=0&navpanes=1`}
-          type="application/pdf" />
-      </object>
-    </div >
-  );
-}
+    return (
+        <div id="pdf-preview-container">
+            <object data={`${content}#toolbar=0&navpanes=1`} type="application/pdf" className="preview-object">
+                <embed src={`${content}#toolbar=0&navpanes=1`} type="application/pdf" />
+            </object>
+        </div>
+    );
+};
 
 export default PdfViewer;

--- a/src/Components/Preview/index.tsx
+++ b/src/Components/Preview/index.tsx
@@ -1,67 +1,65 @@
-import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React from "react";
 
 // import xlsx from 'xlsx';
 // import hljs from 'highlight.js';
 // import { marked } from 'marked';
 
-import PdfViewer from './PdfViewer';
-import HtmlViewer from './HtmlViewer';
-import DocxViewer from './DocxViewer';
-import XlsxViewer from './XlsxViewer';
-import ImageViewer from './ImageViewer';
-import VideoViewer from './VideoViewer';
-import PlaintextViewer from './PlaintextViewer';
-import MarkdownViewer from './MarkdownViewer';
+import PdfViewer from "./PdfViewer";
+import HtmlViewer from "./HtmlViewer";
+import DocxViewer from "./DocxViewer";
+import XlsxViewer from "./XlsxViewer";
+import ImageViewer from "./ImageViewer";
+import VideoViewer from "./VideoViewer";
+import PlaintextViewer from "./PlaintextViewer";
+import MarkdownViewer from "./MarkdownViewer";
 
 // import { readFileRequest, readAssetRequest, readBufferRequest } from '../../Store/ActionCreators/FilesActionCreators';
-import { IAppState } from '../../Store/Reducers';
-import { IFile } from '../../Typings/Store/files';
+import { useAppSelector } from "../../Store/Hooks";
 
 import {
-	IMAGE_TYPES,
-	VIDEO_TYPES,
-	PLAINTEXT_TYPES,
-	HTML_TYPES,
-	MARKDOWN_TYPES,
-	XLSX_TYPES,
-	DOCX_TYPES,
-	PDF_TYPES,
-	extensionMatches,
-} from '../../Config/file.config';
+    IMAGE_TYPES,
+    VIDEO_TYPES,
+    PLAINTEXT_TYPES,
+    HTML_TYPES,
+    MARKDOWN_TYPES,
+    XLSX_TYPES,
+    DOCX_TYPES,
+    PDF_TYPES,
+    extensionMatches,
+} from "../../Config/file.config";
 
 export interface IPreviewProps {
-	filePath: string;
+    filePath: string;
 }
 
 const Preview = ({ filePath }: IPreviewProps): JSX.Element => {
-	// const dispatch = useDispatch();
-	const file = useSelector<IAppState, IFile>((state) => state.files.files?.[filePath]);
+    // const dispatch = useDispatch();
+    const file = useAppSelector((state) => state.files.files?.[filePath]);
 
-	console.log(filePath.split('.')[filePath.split('.').length - 1]);
+    console.log(filePath.split(".")[filePath.split(".").length - 1]);
 
-	const filePathSplit = filePath.split('.');
-	const extension = filePathSplit[filePathSplit.length - 1].toLowerCase();
+    const filePathSplit = filePath.split(".");
+    const extension = filePathSplit[filePathSplit.length - 1].toLowerCase();
 
-	if (extensionMatches(PDF_TYPES, extension)) {
-		return <PdfViewer filePath={filePath} />;
-	} else if (extensionMatches(HTML_TYPES, extension)) {
-		return <HtmlViewer filePath={filePath} />;
-	} else if (extensionMatches(DOCX_TYPES, extension)) {
-		return <DocxViewer filePath={filePath} />;
-	} else if (extensionMatches(XLSX_TYPES, extension)) {
-		return <XlsxViewer filePath={filePath} />;
-	} else if (extensionMatches(IMAGE_TYPES, extension)) {
-		return <ImageViewer filePath={filePath} />;
-	} else if (extensionMatches(VIDEO_TYPES, extension)) {
-		return <VideoViewer filePath={filePath} />;
-	} else if (extensionMatches(PLAINTEXT_TYPES, extension)) {
-		return <PlaintextViewer filePath={filePath} />;
-	} else if (extensionMatches(MARKDOWN_TYPES, extension)) {
-		return <MarkdownViewer filePath={filePath} />;
-	} else {
-		return <div>{JSON.stringify(file)}</div>;
-	}
+    if (extensionMatches(PDF_TYPES, extension)) {
+        return <PdfViewer filePath={filePath} />;
+    } else if (extensionMatches(HTML_TYPES, extension)) {
+        return <HtmlViewer filePath={filePath} />;
+    } else if (extensionMatches(DOCX_TYPES, extension)) {
+        return <DocxViewer filePath={filePath} />;
+    } else if (extensionMatches(XLSX_TYPES, extension)) {
+        return <XlsxViewer filePath={filePath} />;
+    } else if (extensionMatches(IMAGE_TYPES, extension)) {
+        return <ImageViewer filePath={filePath} />;
+    } else if (extensionMatches(VIDEO_TYPES, extension)) {
+        return <VideoViewer filePath={filePath} />;
+    } else if (extensionMatches(PLAINTEXT_TYPES, extension)) {
+        return <PlaintextViewer filePath={filePath} />;
+    } else if (extensionMatches(MARKDOWN_TYPES, extension)) {
+        return <MarkdownViewer filePath={filePath} />;
+    } else {
+        return <div>{JSON.stringify(file)}</div>;
+    }
 };
 
 export default Preview;

--- a/src/Components/Sidebar/index.tsx
+++ b/src/Components/Sidebar/index.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { useDispatch, useSelector } from "react-redux";
 
 import { setActiveTab, updateTab } from "../../Store/ActionCreators/TabActionCreators";
-import { IAppState } from "../../Store/Reducers";
-import { IFavoritesReducerState } from "../../Typings/Store/favorites";
+import { useAppDispatch, useAppSelector } from "../../Store/Hooks";
 
 import XplorerLogo from "../../Icon/extension/xplorer.svg";
 import FavoriteLogo from "../../Icon/folder/sidebar-favorite.svg";
@@ -11,11 +9,11 @@ import HardDiskLogo from "../../Icon/hard-disk.svg";
 import { ThemedDiv, ThemedSpan } from "../Theme";
 
 const Sidebar = () => {
-    const dispatch = useDispatch();
-    const favorites = useSelector<IAppState, IFavoritesReducerState>((state) => state.favorites);
-    const { drives } = useSelector<IAppState, IAppState["drive"]>((state) => state.drive);
+    const dispatch = useAppDispatch();
+    const favorites = useAppSelector((state) => state.favorites);
+    const { drives } = useAppSelector((state) => state.drive);
 
-    const activeTab = useSelector<IAppState, IAppState["tabs"]["activeTab"]>((state) => state.tabs.activeTab);
+    const activeTab = useAppSelector((state) => state.tabs.activeTab);
 
     const favoritesSort = (a: [string, string], b: [string, string]): number => (a[0] > b[0] ? 1 : -1);
 

--- a/src/Store/Hooks/index.ts
+++ b/src/Store/Hooks/index.ts
@@ -1,0 +1,5 @@
+import { useDispatch, useSelector } from "react-redux";
+import { type AppDispatch, type RootState } from "../../Typings/Store/store";
+
+export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
+export const useAppSelector = useSelector.withTypes<RootState>();

--- a/src/Store/index.ts
+++ b/src/Store/index.ts
@@ -3,7 +3,7 @@ import createSagaMiddleware from "redux-saga";
 import { createLogger } from "redux-logger";
 
 import rootSaga from "./Sagas";
-import rootReducer, { IAppState } from "./Reducers";
+import rootReducer from "./Reducers";
 
 const sagaMiddleware = createSagaMiddleware();
 const loggerMiddleware = createLogger();

--- a/src/Typings/Store/store.ts
+++ b/src/Typings/Store/store.ts
@@ -12,6 +12,7 @@ import { StorageActions, StorageActionTypes } from "./storage";
 import { TabActions, TabActionTypes } from "./tab";
 import { WindowActions, WindowActionTypes } from "./window";
 import { SelectionActions, SelectionActionTypes } from "./selection";
+import store from "../../Store";
 
 export type Actions =
     | AppActions
@@ -44,3 +45,6 @@ export type ActionTypes =
     | TabActionTypes
     | WindowActionTypes
     | SelectionActionTypes;
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
This is recommended as per the redux toolkit quickstart https://redux-toolkit.js.org/tutorials/typescript#define-typed-hooks

## Motivation

Specifying the whole Typescript types for each selector is overkill and can easily be simplified

## Changes

Introduce two new hooks, `useAppDispatch` and `useAppSelector` which are type-safe global wrappers for `useDispatch` and `useSelector`
