### PR TITLE
fix invisible text selection in dark theme

### DIFF
--- a/apps/client/src/styles/tokyo-night.css
+++ b/apps/client/src/styles/tokyo-night.css
@@ -168,7 +168,7 @@ select:focus {
 /* Selection styling */
 ::selection {
   background-color: var(--xp-blue);
-  color: var(--xp-bg);
+  color: var(--xp-text);
 }
 
 /* Backdrop blur for dropdowns */


### PR DESCRIPTION
## Summary

file path selection shows invisible text in the dark theme.
<img width="582" height="131" alt="image" src="https://github.com/user-attachments/assets/537c68db-1f9f-4303-a9e5-52cc235d8e83" />

## Changes
change css for text selection. 
-

## Test Plan
<img width="555" height="103" alt="image" src="https://github.com/user-attachments/assets/f39f04b1-787a-4e33-b586-e348f727f2b8" />

